### PR TITLE
POC alternate callback syntax

### DIFF
--- a/Zend/tests/class_name_as_scalar.phpt
+++ b/Zend/tests/class_name_as_scalar.phpt
@@ -2,6 +2,7 @@
 class name as scalar from ::class keyword
 --FILE--
 <?php
+// Keep in sync with fn_callbacks/class_name_resolution.phpt
 
 namespace Foo\Bar {
     class One {

--- a/Zend/tests/fn_callbacks/basic.phpt
+++ b/Zend/tests/fn_callbacks/basic.phpt
@@ -1,0 +1,80 @@
+--TEST--
+fn:: callback basic usage
+--FILE--
+<?php
+
+namespace Foo\Bar {
+    class One {
+        function getThisCallback() {
+            return fn::$this->meth;
+        }
+    }
+    function baz() {
+        return 'Foo.Bar.baz';
+    }
+    function qux() {
+        return baz();
+    }
+
+    echo "Static\n";
+    var_dump(fn::One::method); // resolve in namespace
+    var_dump(fn::\One::mEtHod); // resolve fully qualified
+
+    echo "Dynamic\n";
+    $one = new One();
+    var_dump(fn::$one->meth);
+    var_dump($one->getThisCallback());
+    var_dump($one === $one->getThisCallback()[0]);
+
+    echo "Function\n";
+    var_dump(fn::intval);
+
+    // TODO implement name resolution
+    //var_dump(fn::baz);
+}
+
+namespace {
+    use function Foo\Bar\baz, Foo\Bar\qux;
+    var_dump(fn::iNtVal);
+    var_dump(fn::Foo\intval);
+
+    // TODO implement name resolution
+    //var_dump(fn::baz);
+    //var_dump(fn::qux);
+}
+
+?>
+--EXPECT--
+Static
+array(2) {
+  [0]=>
+  string(11) "Foo\Bar\One"
+  [1]=>
+  string(6) "method"
+}
+array(2) {
+  [0]=>
+  string(3) "One"
+  [1]=>
+  string(6) "mEtHod"
+}
+Dynamic
+array(2) {
+  [0]=>
+  object(Foo\Bar\One)#1 (0) {
+  }
+  [1]=>
+  string(4) "meth"
+}
+array(2) {
+  [0]=>
+  object(Foo\Bar\One)#1 (0) {
+  }
+  [1]=>
+  string(4) "meth"
+}
+bool(true)
+Function
+string(6) "intval"
+string(6) "iNtVal"
+string(10) "Foo\intval"

--- a/Zend/tests/fn_callbacks/class_name_resolution.phpt
+++ b/Zend/tests/fn_callbacks/class_name_resolution.phpt
@@ -1,0 +1,54 @@
+--TEST--
+fn:: callback with static classname
+--FILE--
+<?php
+// Keep in sync with class_name_as_scalar.phpt
+
+namespace Foo\Bar {
+    class One {
+    }
+    class Two extends One {
+        public static function run() {
+            var_dump((fn::self::meth)[0]); // self compile time lookup
+            var_dump((fn::static::meth)[0]); // runtime lookup
+            var_dump((fn::parent::meth)[0]); // runtime lookup
+            var_dump((fn::Baz::meth)[0]); // default compile time lookup
+        }
+    }
+    class Three extends Two {
+    }
+    echo "In NS\n";
+    var_dump((fn::Moo::meth)[0]); // resolve in namespace
+}
+
+namespace {
+    use Bee\Bop as Moo,
+        Foo\Bar\One;
+    echo "Top\n";
+    var_dump((fn::One::meth)[0]); // resolve from use
+    var_dump((fn::Boo::meth)[0]); // resolve in global namespace
+    var_dump((fn::Moo::meth)[0]); // resolve from use as
+    var_dump((fn::\Moo::meth)[0]); // resolve fully qualified
+    Foo\Bar\Two::run(); // resolve runtime lookups
+    echo "Parent\n";
+    Foo\Bar\Three::run(); // resolve runtime lookups with inheritance
+}
+
+?>
+--EXPECT--
+In NS
+string(11) "Foo\Bar\Moo"
+Top
+string(11) "Foo\Bar\One"
+string(3) "Boo"
+string(7) "Bee\Bop"
+string(3) "Moo"
+string(11) "Foo\Bar\Two"
+string(11) "Foo\Bar\Two"
+string(11) "Foo\Bar\One"
+string(11) "Foo\Bar\Baz"
+Parent
+string(11) "Foo\Bar\Two"
+string(13) "Foo\Bar\Three"
+string(11) "Foo\Bar\One"
+string(11) "Foo\Bar\Baz"


### PR DESCRIPTION
This implementation parses a new callback syntax into an AST representing the traditional array/string callback AST.

* `fn::Foo::method` emits `[Foo::class,'method']` - PASS!
* `fn::\Foo::method` emits `[\Foo::class,'method']` - PASS!
* `fn::$foo::method` emits `[$foo,'method']` - PASS!
* `fn::intval` emits `"intval"`. Here a naive implementation just converts the name into a string without proper name resolution. This would need handling like `ZEND_AST_CLASS_NAME`, which can compile to an operation to resolve the name at runtime. Maybe the plumbing is present in [zend_compile_ns_call](https://github.com/php/php-src/blob/86780ff79f041e2507b90f65145d87d493de89e5/Zend/zend_compile.c#L3347) but a new function would need to emit an IS_CONST op instead of ZEND_INIT_NS_FCALL_BY_NAME.